### PR TITLE
Fix & print A-spec Points and % Completion rewards

### DIFF
--- a/COMBINEDEVENTLIST.txt
+++ b/COMBINEDEVENTLIST.txt
@@ -169,17 +169,17 @@ rh_yosemite_dirt_short_h_0000|win|Yosemite Rally II (Hard)
 25,29|mission_1st|1-Lap Magic 25-29
 30,34|mission_1st|1-Lap Magic 30-34
 35,40|mission_1st|Chase Battle 35-40
-25|achievement|25% Completion (Inaccurate)
-50|achievement|50% Completion (Inaccurate)
-100|achievement|100% Completion (Inaccurate)
+25|achievement|25% Completion
+50|achievement|50% Completion
+100|achievement|100% Completion
 am_wagon_0000|win|Super Wagon Series
 us_dodge_viper_0000|win|Snakebite Trophy (Dodge)
 am_fourcyl_0000|win|Four Cylinder Shootout
 am_sixcyl_0000|win|Six Cylinder Shootout
 us_ford_mustang_0000|win|Mustang Showdown (Ford)
-1|aspec|10k A-Spec Points (Inaccurate)
-2|aspec|15k A-Spec Points (Inaccurate)
-3|aspec|20k A-Spec Points (Inaccurate)
+1|aspec_1|10k A-Spec Points
+2|aspec_2|15k A-Spec Points
+3|aspec_3|20k A-Spec Points
 jp_honda_beat_0000|win|Beat the Beat (Honda)
 pr_clubman_race_0400|win|Clubman League
 pr_homologation_0000|win|Homologation Heroes

--- a/Data/FUNCLIST.txt
+++ b/Data/FUNCLIST.txt
@@ -177,9 +177,9 @@ win
 win
 win
 win
-aspec
-aspec
-aspec
+aspec_1
+aspec_2
+aspec_3
 win
 win
 win

--- a/Data/RACENAMES.txt
+++ b/Data/RACENAMES.txt
@@ -169,17 +169,17 @@ Slipstream Battle 21-24
 1-Lap Magic 25-29
 1-Lap Magic 30-34
 Chase Battle 35-40
-25% Completion (Inaccurate)
-50% Completion (Inaccurate)
-100% Completion (Inaccurate)
+25% Completion
+50% Completion
+100% Completion
 Super Wagon Series
 Snakebite Trophy (Dodge)
 Four Cylinder Shootout
 Six Cylinder Shootout
 Mustang Showdown (Ford)
-10k A-Spec Points (Inaccurate)
-15k A-Spec Points (Inaccurate)
-20k A-Spec Points (Inaccurate)
+10k A-Spec Points
+15k A-Spec Points
+20k A-Spec Points
 Beat the Beat (Honda)
 Clubman League
 Homologation Heroes

--- a/s2a/SeedAnalyzer.hs
+++ b/s2a/SeedAnalyzer.hs
@@ -12,7 +12,6 @@ import S2RA.Typedefs
 main :: IO ()
 main = do
   putStrLn "Gran Turismo 4 Spec II v1.06.X Prize Car Randomizer Brute-Forcer\nMade by Azullia / 0xFC963F18DC21\nSpecial Thanks to Nenkai, TeaKanji\n"
-  putStrLn "Please note that as of currently, the Game % Completion and A-Spec point\nreward cars are not accurate / correct to how they are in-game.\n"
 
   sp2Data <- loadData
 


### PR DESCRIPTION
% Completion seems to be working as is, so just needs the (Inaccurate) tag removed?

A-spec Points was inaccurate due to it using an older & since replaced func name, see
([TheAdmiester/OpenAdhoc-GT4SpecII: change 7a70f900d64 for src/projects/gt4o_us/gtmode/US_carlist.ad line 1922](https://github.com/TheAdmiester/OpenAdhoc-GT4SpecII/commit/7a70f900d64607d66e7c2292d3b9981b5ca124d3#diff-453d8081827a752cdb863f077a24a7a1ee9965ae9b24adc464c7dbf88091998bL1922))

You'll have more tests than I do, but they seem to be accurate from a quick check with people.